### PR TITLE
✨ feat: add big-bear-ncdu docker-compose service

### DIFF
--- a/how-to-install-ncdu-on-portainer/README.md
+++ b/how-to-install-ncdu-on-portainer/README.md
@@ -1,0 +1,1 @@
+## YouTube Video

--- a/how-to-install-ncdu-on-portainer/docker-compose.yml
+++ b/how-to-install-ncdu-on-portainer/docker-compose.yml
@@ -1,0 +1,37 @@
+# Service definitions for the big-bear-ncdu application
+services:
+  # Service name: big-bear-ncdu
+  # The `big-bear-ncdu` service definition
+  big-bear-ncdu:
+    # Name of the container
+    container_name: big-bear-ncdu
+
+    # Image to be used for the container specifies the ncdu version and source
+    image: bigbeartechworld/big-bear-ncdu:0.0.2
+
+    # Container restart policy - restarts the container unless manually stopped
+    restart: unless-stopped
+
+    # Run the container in privileged mode to allow access to system metrics
+    privileged: true
+
+    # Mount necessary volumes for accessing system information
+    volumes:
+      # Mount the host's /proc directory to the container's /proc directory
+      - /proc:/proc
+      # Mount the host's /sys directory to the container's /sys directory
+      - /sys:/sys
+      # Mount the host's /dev directory to the container's /dev directory
+      - /dev:/dev
+      # Mount the host's /etc/localtime file to the container's /etc/localtime file (read-only)
+      - /etc/localtime:/etc/localtime:ro
+      # Mount the host's root directory to the container's /portainer directory
+      - /:/portainer
+
+    # Map port 7681 on the host to port 7681 on the container
+    ports:
+      - "7681:7681"
+
+    # Environment variables to be set in the container for application configuration
+    environment:
+      - NCDU_PATH=/


### PR DESCRIPTION
Adds a new Docker Compose service named "big-bear-ncdu" that runs the
NCDU (ncurses disk usage) utility in a privileged container. The
container mounts various host directories to access system metrics and
exposes port 7681 for accessing the NCDU web interface.

This change allows users to easily deploy the NCDU application on a
Portainer instance using the provided Docker Compose configuration.