### PR TITLE
✨ feat: Add Docker Compose configuration for ncdu application

### DIFF
--- a/how-to-install-ncdu-on-dockge/README.md
+++ b/how-to-install-ncdu-on-dockge/README.md
@@ -1,0 +1,1 @@
+## YouTube Video

--- a/how-to-install-ncdu-on-dockge/docker-compose.yml
+++ b/how-to-install-ncdu-on-dockge/docker-compose.yml
@@ -1,0 +1,37 @@
+# Service definitions for the big-bear-ncdu application
+services:
+  # Service name: big-bear-ncdu
+  # The `big-bear-ncdu` service definition
+  big-bear-ncdu:
+    # Name of the container
+    container_name: big-bear-ncdu
+
+    # Image to be used for the container specifies the ncdu version and source
+    image: bigbeartechworld/big-bear-ncdu:0.0.2
+
+    # Container restart policy - restarts the container unless manually stopped
+    restart: unless-stopped
+
+    # Run the container in privileged mode to allow access to system metrics
+    privileged: true
+
+    # Mount necessary volumes for accessing system information
+    volumes:
+      # Mount the host's /proc directory to the container's /proc directory
+      - /proc:/proc
+      # Mount the host's /sys directory to the container's /sys directory
+      - /sys:/sys
+      # Mount the host's /dev directory to the container's /dev directory
+      - /dev:/dev
+      # Mount the host's /etc/localtime file to the container's /etc/localtime file (read-only)
+      - /etc/localtime:/etc/localtime:ro
+      # Mount the host's root directory to the container's /portainer directory
+      - /:/portainer
+
+    # Map port 7681 on the host to port 7681 on the container
+    ports:
+      - "7681:7681"
+
+    # Environment variables to be set in the container for application configuration
+    environment:
+      - NCDU_PATH=/


### PR DESCRIPTION
This commit introduces a Docker Compose configuration file for the `big-bear-ncdu`
application. The key changes include:

- Defines a service for the `big-bear-ncdu` application
- Specifies the Docker image to be used for the container
- Sets the container restart policy to `unless-stopped`
- Runs the container in privileged mode to access system metrics
- Mounts necessary volumes for accessing system information
- Maps port 7681 on the host to port 7681 on the container
- Sets environment variables for application configuration

Additionally, this commit adds a new README.md file with a reference to a
YouTube video.