### PR TITLE
🔧 fix(immich): update server port in docker-compose

### DIFF
--- a/how-to-install-immich-on-dockge/docker-compose.yml
+++ b/how-to-install-immich-on-dockge/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     container_name: immich-server # Name of the running container
     image: ghcr.io/immich-app/immich-server:v1.118.2 # Image to be used
     ports: # Mapping ports from the host OS to the container
-      - 2283:3001
+      - 2283:2283
     volumes: # Mounting directories for persistent data storage
       - immich_upload:/usr/src/app/upload
     environment: # Setting environment variables

--- a/how-to-install-immich-on-portainer/docker-compose.yml
+++ b/how-to-install-immich-on-portainer/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     container_name: immich-server # Name of the running container
     image: ghcr.io/immich-app/immich-server:v1.118.2 # Image to be used
     ports: # Mapping ports from the host OS to the container
-      - 2283:3001
+      - 2283:2283
     volumes: # Mounting directories for persistent data storage
       - immich_upload:/usr/src/app/upload
     environment: # Setting environment variables


### PR DESCRIPTION
Changes the server port mapping in the docker-compose.yml files for
both the Dockge and Portainer instructions from 3001 to 2283. This
ensures that the Immich server container is exposed on the correct
port, matching the default configuration.