### PR TITLE
✨ feat(umbrel): mount big_bear_umbrel_data directory to container

### DIFF
--- a/how-to-install-umbrel-os-on-portainer/docker-compose.yml
+++ b/how-to-install-umbrel-os-on-portainer/docker-compose.yml
@@ -19,7 +19,7 @@ services:
 
     # Volumes to be mounted to the container
     volumes:
-      # Mounting the local /DATA/AppData/$AppID directory to /data inside the container
+      # Mounting the local big_bear_umbrel_data directory to /data inside the container
       - big_bear_umbrel_data:/data
 
       # Mounting docker.sock to allow docker management via Umbrel


### PR DESCRIPTION
# Mount big_bear_umbrel_data directory to Umbrel container

## Description
This pull request mounts the local `big_bear_umbrel_data` directory to the `/data` directory inside the Umbrel container. This allows the Umbrel application to access and manage the necessary data.

## Changes
- Mounts the local `big_bear_umbrel_data` directory to the `/data` directory inside the Umbrel container.