### PR TITLE
🎨 feat(stirling-pdf): Add YouTube video and Docker Compose configuration

### DIFF
--- a/how-to-install-stirling-pdf-on-portainer/README.md
+++ b/how-to-install-stirling-pdf-on-portainer/README.md
@@ -1,0 +1,1 @@
+## YouTube Video

--- a/how-to-install-stirling-pdf-on-portainer/docker-compose.yml
+++ b/how-to-install-stirling-pdf-on-portainer/docker-compose.yml
@@ -1,0 +1,59 @@
+# Service definitions for the big-bear-stirling-pdf application
+services:
+  # Main service configuration for the Stirling PDF application
+  # This service provides a web interface running on port 8080 for PDF editing
+  big-bear-stirling-pdf:
+    # Name of the container
+    container_name: big-bear-stirling-pdf
+
+    # Image to be used for the container specifies the stirling-pdf version and source
+    image: stirlingtools/stirling-pdf:0.37.1
+
+    # Container restart policy - restarts the container unless manually stopped
+    restart: unless-stopped
+
+    # Environment variables for service configuration
+    environment:
+      # Set to true to download security jar (required for authentication login)
+      - DOCKER_ENABLE_SECURITY=false
+
+      # Set to true to enable login for authentication
+      - SECURITY_ENABLE_LOGIN=true
+
+      # Set the initial admin username
+      - SECURITY_INITIALLOGIN_USERNAME=bigbear
+
+      # Set the initial admin password
+      - SECURITY_INITIALLOGIN_PASSWORD=4500733e-a0f8-4605-a712-fd267404956a
+
+      # Set to true to enable CSRF protection
+      - CSRF_DISABLED=false
+
+      # Set the default locale for the application
+      - DEFAULT_LOCALE=en-US
+
+      # Download Calibre onto Stirling-PDF to enable PDF to/from book and advanced HTML conversion
+      - INSTALL_BOOK_AND_ADVANCED_HTML_OPS=false
+
+      # Define custom font libraries to install for document conversions
+      - LANGS=en_US
+
+    # Volume mappings for persistent storage and configuration
+    # These mounts allow the container to interact with the host system
+    volumes:
+      # Required for monitoring system resources and container metrics
+      - big_bear_stirling_pdf_tessdata:/usr/share/tessdata # Required for extra OCR languages
+      - big_bear_stirling_pdf_configs:/configs
+
+    # Map port 8080 on the host to port 8080 on the container
+    ports:
+      - "8080:8080"
+
+# Volumes for the Stirling PDF service
+volumes:
+  big_bear_stirling_pdf_tessdata:
+    name: big_bear_stirling_pdf_tessdata
+    driver: local
+  big_bear_stirling_pdf_configs:
+    name: big_bear_stirling_pdf_configs
+    driver: local


### PR DESCRIPTION
This pull request introduces the following changes:

1. Adds a new README.md file in the `how-to-install-stirling-pdf-on-portainer` directory, which includes a reference to a YouTube video.
2. Adds a new `docker-compose.yml` file in the `how-to-install-stirling-pdf-on-portainer` directory, which defines the service configuration for the Stirling PDF application. This includes setting up environment variables, volume mappings, and port forwarding.

The changes were made to provide a comprehensive guide for installing and running the Stirling PDF application on Portainer, including a reference to a video tutorial and the necessary Docker Compose configuration.