### PR TITLE
Add dockpeek apps for Portainer and Dockge

### DIFF
--- a/dockge/dockpeek/README.md
+++ b/dockge/dockpeek/README.md
@@ -1,0 +1,7 @@
+## YouTube Video
+
+## DockPeek Icon
+
+```text
+https://cdn.jsdelivr.net/gh/selfhst/icons/png/dockpeek.png
+```

--- a/dockge/dockpeek/docker-compose.yml
+++ b/dockge/dockpeek/docker-compose.yml
@@ -1,0 +1,33 @@
+version: "3" # Specifies the version of the Docker Compose file format
+
+services:
+  # Service name: big-bear-dockpeek
+  # The `big-bear-dockpeek` service definition
+  big-bear-dockpeek:
+    # Name of the container
+    container_name: big-bear-dockpeek
+
+    # Image to be used for the container
+    image: ghcr.io/dockpeek/dockpeek:v1.5.5
+
+    # Container restart policy
+    restart: unless-stopped
+
+    # Volumes to be mounted to the container
+    volumes:
+      # Mounting docker.sock to allow docker management via DockPeek
+      - /var/run/docker.sock:/var/run/docker.sock
+
+    # Environment variables
+    environment:
+      # Secret key for the application
+      - SECRET_KEY=your-secret-key-here
+      # Username for login
+      - USERNAME=admin
+      # Password for login
+      - PASSWORD=changeme
+
+    # Ports mapping between host and container
+    ports:
+      # Mapping port 3420 of the host to port 8000 of the container
+      - "3420:8000"

--- a/portainer/dockpeek/README.md
+++ b/portainer/dockpeek/README.md
@@ -1,0 +1,7 @@
+## YouTube Video
+
+## DockPeek Icon
+
+```text
+https://cdn.jsdelivr.net/gh/selfhst/icons/png/dockpeek.png
+```

--- a/portainer/dockpeek/docker-compose.yml
+++ b/portainer/dockpeek/docker-compose.yml
@@ -1,0 +1,33 @@
+version: "3" # Specifies the version of the Docker Compose file format
+
+services:
+  # Service name: big-bear-dockpeek
+  # The `big-bear-dockpeek` service definition
+  big-bear-dockpeek:
+    # Name of the container
+    container_name: big-bear-dockpeek
+
+    # Image to be used for the container
+    image: ghcr.io/dockpeek/dockpeek:v1.5.5
+
+    # Container restart policy
+    restart: unless-stopped
+
+    # Volumes to be mounted to the container
+    volumes:
+      # Mounting docker.sock to allow docker management via DockPeek
+      - /var/run/docker.sock:/var/run/docker.sock
+
+    # Environment variables
+    environment:
+      # Secret key for the application
+      - SECRET_KEY=your-secret-key-here
+      # Username for login
+      - USERNAME=bigbear
+      # Password for login
+      - PASSWORD=portainer
+
+    # Ports mapping between host and container
+    ports:
+      # Mapping port 3420 of the host to port 8000 of the container
+      - "3420:8000"


### PR DESCRIPTION
## Summary
- Add dockpeek Docker dashboard apps for both Portainer and Dockge platforms
- Use specific version tag (v1.5.5) instead of latest for consistency
- Configure proper Docker socket access and environment variables

## Test plan
- [ ] Verify docker-compose.yml files are properly formatted
- [ ] Test deployment on Portainer platform
- [ ] Test deployment on Dockge platform
- [ ] Confirm dockpeek dashboard loads at port 3420